### PR TITLE
automatic basedir

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+const { dirname } = require('path');
 const { createFilter } = require('rollup-pluginutils');
 const { compile } = require('glslify');
 
@@ -18,12 +19,14 @@ module.exports = function glslify(userOptions = {}) {
         ]
     }, userOptions);
 
+    const basedir = options.basedir;
+
     const filter = createFilter(options.include, options.exclude);
 
     return {
         transform(code, id) {
             if (!filter(id)) return;
-
+            options.basedir = basedir || dirname(id);
             return {
                 code: `export default ${JSON.stringify(compile(code, options))}; // eslint-disable-line`,
                 map: { mappings: '' }


### PR DESCRIPTION
Hi, @pschroen 

Thanks for your work at first.

This is a patch to fix a bug when using [lerna](https://github.com/lerna/lerna) and rollup-plugin-glslify together:

In lerna, dependencies can be [added to modules by folder symlinks](https://github.com/lerna/lerna#add). In this case, when **basedir** is not present, rollup-plugin-glslify will throw an error reporting unable to find glsl files due to symlinks mentioned above.

This patch can fix this problem with respect of the original options.

