### PR TITLE
Make default baseDir relative to each file

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,10 +25,12 @@ module.exports = function glslify(userOptions = {}) {
         transform(code, id) {
             if (!filter(id)) return;
 
-            options.basedir = options.basedir || dirname(id);
+            const fileOptions = Object.assign({
+                basedir: dirname(id)
+            }, options);
 
             return {
-                code: `export default ${JSON.stringify(compile(code, options))}; // eslint-disable-line`,
+                code: `export default ${JSON.stringify(compile(code, fileOptions))}; // eslint-disable-line`,
                 map: { mappings: '' }
             };
         }


### PR DESCRIPTION
I was having a problem with relative imports and I fixed it this way.

```
- chunks
  - common.glsl
- flat
  - vertex.glsl
- phong
  - custom.glsl
  - vertex.glsl
```

I import on my js code
```javascript 
import flatVertex from "./flat/vertex.glsl";
import phongVertex from "./phong/vertex.glsl";

...
```

And then lets look at `phong/vertex.glsl`
```glsl
#version 300 es
#pragma glslify: import("../chunks/common.glsl")
#pragma glslify: import("./common.glsl")
```

The problem I get with that is that the first file processed in this case `flat/vertex.glsl` sets options.baseDir to `flat/` and the second `phong/vertex.glsl` file uses that same baseDir `flat/` instead of `phong/` resulting in a relative import not being found (`./common.glsl`).