### PR TITLE
Fix imported files not causing watch mode updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "test": "node ./test/index.js"
   },
   "dependencies": {
-    "glslify": "^7.1.1",
-    "rollup-pluginutils": "^2.8.2"
+    "glslify-bundle": "^5.1.1",
+    "glslify-deps": "^1.3.2",
+    "rollup-pluginutils": "^2.8.2",
+    "stack-trace": "0.0.9"
   },
   "devDependencies": {
     "eslint": "^8.23.1",


### PR DESCRIPTION
When using `vite` or `rollup --watch`, editing a shader file that is only imported by another shader file via glslify doesn't trigger a rebuild. This PR fixes that. See https://github.com/vitejs/vite/issues/1614#issuecomment-789141676.

There is some duplication caused by inlining the compile function from glslify, which is required to keep supporting the [glslify API options](https://github.com/glslify/glslify#var-src--glslcompilesrc-opts) mentioned in this project's README. We can coordinate with the glslify repo to remove this duplication in the future.

This fix only takes effect if `addWatchFile` works, i.e. [Vite >=4](https://github.com/vitejs/vite/pull/9723#issuecomment-1316959350) or [Rollup not on Linux](https://github.com/rollup/rollup/issues/4508).